### PR TITLE
run 'npm run build' as part of CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,3 +14,6 @@ jobs:
 
       - name: Install dependencies and run tests
         run: npm install && npm test
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
I think it's valuable to have a CI step that validates the build script actually runs (otherwise we could end up creating a release that doesn't build)