### PR TITLE
Fix an issue if data-setup is not present on the video element

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Of course, you can also initialize all of this via JS as well:
   preload="auto"
   width="100%"
   poster="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/thumbnail.jpg"
-  data-setup='{}'
 />
 
 <script type="text/javascript">
@@ -80,4 +79,4 @@ Of course, you can also initialize all of this via JS as well:
 </script>
 ```
 
-Also, the [demos](./src/demo) are a great place to more references! In general, you can expect this to work almost exactly like Video.js + Mux Data with a few extra niceties. Mux streams can be specified by simply including the playback ID as the `src`, and `video/mux` as the type.
+Also, the [demos](https://github.com/muxinc/videojs-mux-kit/tree/main/src/demo) are a great place to more references! In general, you can expect this to work almost exactly like Video.js + Mux Data with a few extra niceties. Mux streams can be specified by simply including the playback ID as the `src`, and `video/mux` as the type.

--- a/src/utils/mux-data-middleware.js
+++ b/src/utils/mux-data-middleware.js
@@ -15,7 +15,7 @@ function setupMuxDataTracking (player) {
 function setupMuxDataMetadataOverride (videoEl, options) {
   // depending which way Mux Data is init'd, we have to inject metadata in different ways
   // we'll start with if we get init'd on the data-setup element
-  if (videoEl?.dataset?.setup && videoEl.dataset.setup !== undefined) {
+  if (videoEl?.dataset?.setup) {
     let setup = videoEl.dataset.setup;
     setup = JSON.parse(setup);
     if (setup && setup?.plugins?.mux?.data) {

--- a/src/utils/mux-data-middleware.js
+++ b/src/utils/mux-data-middleware.js
@@ -15,12 +15,15 @@ function setupMuxDataTracking (player) {
 function setupMuxDataMetadataOverride (videoEl, options) {
   // depending which way Mux Data is init'd, we have to inject metadata in different ways
   // we'll start with if we get init'd on the data-setup element
-  let setup = JSON.parse(videoEl.dataset?.setup);
-  if (setup && setup?.plugins?.mux?.data) {
-    // Mux data was configured on the video element
-    setup = injectMuxDataMetadata(setup);
-    setup = JSON.stringify(setup);
-    videoEl.dataset.setup = setup;
+  if (videoEl?.dataset?.setup && videoEl.dataset.setup !== undefined) {
+    let setup = videoEl.dataset.setup;
+    setup = JSON.parse(setup);
+    if (setup && setup?.plugins?.mux?.data) {
+      // Mux data was configured on the video element
+      setup = injectMuxDataMetadata(setup);
+      setup = JSON.stringify(setup);
+      videoEl.dataset.setup = setup;
+    }
   }
   
   // the other way is if we init via JS, which comes through here instead


### PR DESCRIPTION
- bug fix to stop an error when no data-setup attribute is present on the video element