### PR TITLE
Ensure WKWebView playback uses native HLS

### DIFF
--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -29,8 +29,9 @@ class HlsJs {
   }
 
   setupHls() {
-    if (this.el.canPlayType('application/vnd.apple.mpegurl') && isSafari()) {
-      // We're using Safari, so let's stick with the native HLS engine
+    if (this.el.canPlayType('application/vnd.apple.mpegurl') && videojs.browser.IS_ANY_SAFARI) {
+      // We're using Safari (or another apple component like WKWebView), so let's 
+      // stick with the native HLS engine
       // Other browsers such as IE edge do have native support, but generally 
       // it's not perfect, so let those fall through to use HLS.js instead
       this.el.src = this.source.src;
@@ -68,10 +69,6 @@ const sourceHandler = {
     return "";
   },
 };
-
-const isSafari = () => (
-  navigator && typeof navigator !== undefined && (navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.search('Chrome') === -1)
-);
 
 videojs.getTech('Html5').registerSourceHandler(sourceHandler, 0);
 


### PR DESCRIPTION
- Solve an issue where the previous release (v0.1.4) still attempts to use hls.js when loaded in a `WKWebView` component. Video.js has built in browser detection capabilities, so lets use this to determine if an apple device is in use or not