### PR TITLE
Support signed urls

### DIFF
--- a/src/demo/signed.html
+++ b/src/demo/signed.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head> </head>
+
+<body>
+  <h1>Mux Video.js Kit</h1>
+
+  <section>
+    <h2>Signed URLs</h2>
+    <video id="mux-default" class="video-js vjs-16-9" controls preload="auto" width="100%"
+      poster="https://image.mux.com/Dy2kXJmOPNBk8hdRGuBPJWwWT1dmeJ02u/thumbnail.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJEeTJrWEptT1BOQms4aGRSR3VCUEpXd1dUMWRtZUowMnUiLCJhdWQiOiJ0IiwiZXhwIjoxNjU3MjA4ODI2LCJraWQiOiJTbk52RGc4UldsUjAxTE5WQkRJd2JSUFhDOVhHM2pIUWcifQ.NpRVHdy1k9yheTjhoabZqvdGylndf8bNZFF4UrQLuYjj_Jm-43IE-5TxwGWFGGjU8ohaDjlgGVfZosD77htqivr7lWXeCGUyTPZj5dBjd8Dbsk8IdPjRD70rlY85t4oUCgE_8qPaX3YOAxbFHa56LunEgx83PBfSPz7UsQtPzVqpw5BPPdHR5v_FpX5YLV8IZIumC7YfK1a8X6GN-WOikTzqVpdhBNn2P36YbB4ZRSOQ4hw_B8VCEc0HIAc2ly59EhBwLduWpAOtsbSG6nyaNAsejNcUBABw1wIG3xZ1he7e_jnZjhaE2Yx-8EbLxXdlYyxzZquYoSiSz_M8AKUc2g"
+      data-setup='{
+          "timelineHoverPreviewsUrl": "https://image.mux.com/Dy2kXJmOPNBk8hdRGuBPJWwWT1dmeJ02u/storyboard.vtt?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJEeTJrWEptT1BOQms4aGRSR3VCUEpXd1dUMWRtZUowMnUiLCJhdWQiOiJzIiwiZXhwIjoxNjU3MjA4Nzc2LCJraWQiOiJTbk52RGc4UldsUjAxTE5WQkRJd2JSUFhDOVhHM2pIUWcifQ.ewd35Ij7NdWosGR-jLAX601TIFn09YHAFNPzUpBWRz2yI9AlJGjE3mBTdYVHZ79_sfvjwwGD13xhdk1mqq1xn6Nit2SQZNDrcnCirwflVAFjU5rr5NbdOLmnlXZfQSyDFJTdb5op9GE2Lfa83nc5YfhgMjukPgTk3nD3wGTgYtaKtKQofkb3w9mIyASYLHaPqCBm4rmyVyDlQ4LiGFgJY95_sFmXnTIZUqNtUli0k3c_61P3OTA3S00uNyRjVI7CRegZnXMGTxZPe_22tpCNrn4ZQ4OFjulLizaWw2Fmi6J9TFSgDDPC-inPdwATbNPK0QVPcBt_RM1gu9yz46pQuQ",
+          "plugins": {
+            "mux": {
+              "debug": true,
+              "data":{
+                "env_key": "ENV_KEY",
+                "video_title": "Mad Max"
+              }
+            }
+          }
+        }'
+      >
+      <source src="Dy2kXJmOPNBk8hdRGuBPJWwWT1dmeJ02u?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJEeTJrWEptT1BOQms4aGRSR3VCUEpXd1dUMWRtZUowMnUiLCJhdWQiOiJ2IiwiZXhwIjoxNjU3MjA4ODAzLCJraWQiOiJTbk52RGc4UldsUjAxTE5WQkRJd2JSUFhDOVhHM2pIUWcifQ.Guyii5C-TrY_S3YRnYshRrc7-ULkHeWhFlUUgsqMYOpqbx9Rt---marqnTQ53sd54vLMCUsBg8aXPAvBDW5l7_-qNFeNQKNmYZzY9NVjiz_7f-ZSa-AUvEsmpFwMEjtAKiBWVlsvx5wKjRikMpx1GPVNtRk-pSwhrj9py-o-375BoJN6BbNb4xuPbutqSFUXLwYI0OK3TQXjpebn-52ov-vJcJiIFd56bR11dAfiDX5M00VMd3BPSS61Po2cV54xkDVgNNkvBu4_v5z7noLGc__O_qPhlUB-bRehYbPWC-dYnHgCsgZ5efjJ0rcD74vxMk9lOrpj2zNXmPs2NNwimg" type="video/mux" />
+    </video>
+  </section>
+</body>
+
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import {setupMuxDataTracking, setupMuxDataMetadataOverride} from './utils/mux-da
 import {setupSubtitlesForPlayer} from './utils/mux-subtitles';
 import {setupTimelineHoverPreviewsHelper} from './utils/mux-timelineHoverPreviews';
 
+let vttThumbnailsInitialized = false;
+
 videojs.hook('beforesetup', function(videoEl, options) {
   // We might have Mux Data enabled, and we need to handle overriding some metadata
   options = setupMuxDataMetadataOverride(videoEl, options);

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@ import {setupMuxDataTracking, setupMuxDataMetadataOverride} from './utils/mux-da
 import {setupSubtitlesForPlayer} from './utils/mux-subtitles';
 import {setupTimelineHoverPreviewsHelper} from './utils/mux-timelineHoverPreviews';
 
-let vttThumbnailsInitialized = false;
-
 videojs.hook('beforesetup', function(videoEl, options) {
   // We might have Mux Data enabled, and we need to handle overriding some metadata
   options = setupMuxDataMetadataOverride(videoEl, options);
@@ -29,7 +27,7 @@ videojs.use('video/mux', (player) => {
   return {
     setSource({ src }, next) {
 
-      if (player.options().timelineHoverPreviews) {
+      if (player.options().timelineHoverPreviews && !player.options().timelineHoverPreviewsUrl) {
         // strip off any playback related query string parameters, so the
         // storyboard url is not malformed
         let playbackId = src.split(`?`, 1);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import './tech/hlsjs';
 import {setupMuxDataTracking, setupMuxDataMetadataOverride} from './utils/mux-data-middleware';
 import {setupSubtitlesForPlayer} from './utils/mux-subtitles';
 
+let vttThumbnailsInitialized = false;
+
 videojs.hook('beforesetup', function(videoEl, options) {
   // We might have Mux Data enabled, and we need to handle overriding some metadata
   options = setupMuxDataMetadataOverride(videoEl, options);
@@ -22,10 +24,21 @@ videojs.use('video/mux', (player) => {
         // strip off any playback related query string parameters, so the
         // storyboard url is not malformed
         let playbackId = src.split(`?`, 1);
+        let storyboardUrl = `https://image.mux.com/${playbackId[0]}/storyboard.vtt`;
+
+        if (player.options().timelineHoverPreviews.token) {
+          // append the token to the storyboard request, if a token is provided
+          storyboardUrl = storyboardUrl + `?token=` + player.options().timelineHoverPreviews.token;
+        }
         
-        player.vttThumbnails({
-          src: `https://image.mux.com/${playbackId[0]}/storyboard.vtt`,
-        });
+        if (!vttThumbnailsInitialized) {
+          // this is the first time the video is loaded, so setup the plugin
+          player.vttThumbnails({src: storyboardUrl});
+          vttThumbnailsInitialized = true;
+        } else {
+          // we already have a vttThumbnails plugin running, so just update the src
+          player.vttThumbnails.src(storyboardUrl);
+        }
       }
 
       next(null, {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ videojs.use('video/mux', (player) => {
   return {
     setSource({ src }, next) {
 
-      if (player.options().timelineHoverPreviews && !player.options().timelineHoverPreviewsUrl) {
+      if (player.options().timelineHoverPreviews) {
         // strip off any playback related query string parameters, so the
         // storyboard url is not malformed
         let playbackId = src.split(`?`, 1);

--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -9,7 +9,7 @@ class HlsJs {
     this.source = source;
     this.tech = tech;
     this.el = tech.el();
-    this.hls = new Hls(options.hls);
+    this.hls = new Hls({ ...options.hls, liveDurationInfinity: true });
 
     this.setupEventHandlers();
     this.setupHls();

--- a/src/utils/mux-timelineHoverPreviews.js
+++ b/src/utils/mux-timelineHoverPreviews.js
@@ -1,0 +1,37 @@
+import '../plugins/vtt-thumbnails.js';
+
+let vttThumbnailsInitialized = false;
+
+function setupTimelineHoverPreviewsHelper(player) {
+
+  player.timelineHoverPreviews = function(options) {
+
+    let enabled = options?.enabled || false;
+    let source = options?.src || null;
+  
+    if (!enabled && vttThumbnailsInitialized) {
+      // if timelineHoverPreviews were enabled, remove them
+      player.vttThumbnails.detach();
+      player.options().timelineHoverPreviewsUrl = null;
+      return;
+  
+    } else if (!vttThumbnailsInitialized && source !== null) {
+      // if this is the first time the player instance has a timelineHoverPreviews source,
+      // init the plugin with the source
+      player.vttThumbnails({src: source});
+      vttThumbnailsInitialized = true;
+      player.options().timelineHoverPreviewsUrl = source;
+      return;
+  
+    } else if (vttThumbnailsInitialized && source !== null) {
+      // the plugin is already running, so just update to the new source
+      player.vttThumbnails.src(source);
+      player.options().timelineHoverPreviewsUrl = source;
+      return;
+  
+    }
+  }
+
+}
+
+export { setupTimelineHoverPreviewsHelper }

--- a/src/utils/mux-timelineHoverPreviews.js
+++ b/src/utils/mux-timelineHoverPreviews.js
@@ -1,7 +1,5 @@
 import '../plugins/vtt-thumbnails.js';
 
-let vttThumbnailsInitialized = false;
-
 function setupTimelineHoverPreviewsHelper(player) {
 
   player.timelineHoverPreviews = function(options) {
@@ -9,21 +7,20 @@ function setupTimelineHoverPreviewsHelper(player) {
     let enabled = options?.enabled || false;
     let source = options?.src || null;
   
-    if (!enabled && vttThumbnailsInitialized) {
+    if (!enabled && typeof(player.vttThumbnails.detach) === 'function') {
       // if timelineHoverPreviews were enabled, remove them
       player.vttThumbnails.detach();
       player.options().timelineHoverPreviewsUrl = null;
       return;
   
-    } else if (!vttThumbnailsInitialized && source !== null) {
+    } else if (typeof(player.vttThumbnails) === 'function' && source !== null) {
       // if this is the first time the player instance has a timelineHoverPreviews source,
       // init the plugin with the source
       player.vttThumbnails({src: source});
-      vttThumbnailsInitialized = true;
       player.options().timelineHoverPreviewsUrl = source;
       return;
   
-    } else if (vttThumbnailsInitialized && source !== null) {
+    } else if (typeof(player.vttThumbnails.src) === 'function'&& source !== null) {
       // the plugin is already running, so just update to the new source
       player.vttThumbnails.src(source);
       player.options().timelineHoverPreviewsUrl = source;


### PR DESCRIPTION
### Support signed URLs

Signed urls are unofficially supported by passing a token query string parameter along with the playback_id when setting a source (`playback_id?token=JWT`). This approach works, but breaks if `timelineHoverPreviews` are enabled, since they require a different `aud` claim in the JWT to the video (they can't share the same token). This PR is to address this issue.

#### Still to do:

- [ ] add a test for signed urls
- [ ] add a test for changing the source

Thoughts?