### PR TITLE
Configure Hls.js to work with live streams

### DIFF
--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -9,7 +9,7 @@ class HlsJs {
     this.source = source;
     this.tech = tech;
     this.el = tech.el();
-    this.hls = new Hls(options.hls);
+    this.hls = new Hls({ ...options.hls, liveDurationInfinity: true });
 
     this.setupEventHandlers();
     this.setupHls();


### PR DESCRIPTION
When `videojs-mux-kit` is using the Hls.js tech, we need to force live streams to use `Infinity` as a duration so that video.js renders the live control UI appropriately. 

- Added `liveDurationInfinity` to the Hls.js configuration to support live streams
