### PR TITLE
Update logic for Native vs. Hls.js engines

### DIFF
--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -29,15 +29,12 @@ class HlsJs {
   }
 
   setupHls() {
-    if (this.el.canPlayType('application/vnd.apple.mpegurl') && videojs.browser.IS_ANY_SAFARI) {
-      // We're using Safari (or another apple component like WKWebView), so let's 
-      // stick with the native HLS engine
-      // Other browsers such as IE edge do have native support, but generally 
-      // it's not perfect, so let those fall through to use HLS.js instead
+    // Browser natively supports HLS
+    if (this.el.canPlayType('application/vnd.apple.mpegurl')) {
       this.el.src = this.source.src;
-
-      // Check if HLS.js is supported
-    } else if (Hls.isSupported()) {
+    }
+    // Browser doesn't natively support HLS, but can support using Hls.js
+    else if (Hls.isSupported()) {
       this.hls.attachMedia(this.el);
       this.hls.loadSource(this.source.src);
     }


### PR DESCRIPTION
- We favor engines that allow for HLS in players within browsers
- If no native but browser supports Hls.js, use Hls.js
- If browser is can't handle native or hls.js, then playback will fail