### PR TITLE
check MSE first, then fallback to native HLS

### DIFF
--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -29,14 +29,13 @@ class HlsJs {
   }
 
   setupHls() {
-    // Browser natively supports HLS
-    if (this.el.canPlayType('application/vnd.apple.mpegurl')) {
-      this.el.src = this.source.src;
-    }
-    // Browser doesn't natively support HLS, but can support using Hls.js
-    else if (Hls.isSupported()) {
+    if (Hls.isSupported()) {
       this.hls.attachMedia(this.el);
       this.hls.loadSource(this.source.src);
+    } else if (this.el.canPlayType('application/vnd.apple.mpegurl')) {
+      this.el.src = this.source.src;
+    } else {
+      console.log('[videojs-mux-kit] Error: browser does not support MSE nor Hls natively');
     }
   }
 }


### PR DESCRIPTION
closes #39 

Changes logic to the following

- check for MSE support first (`Hls.isSupported()`)
- then fallback to check for native HLS support

Unfortunately, the logic we had before of checking native HLS support first is leading to a bug in Android.

For some reason, on Android, when setting `this.el.src = "....m3u8"` it throws a CODE4 error. Note that this only happens with videojs. If we strip out videojs all together and set `src="....m3u8"` on a `<video>` element then the bug doesn't happen. So it has something to do with the videojs stack throwing this error specifically on Android and I couldn't get to the bottom of it.

Note that on Safari setting  `this.el.src = "....m3u8"` w/ videojs did not throw the error, so there's really something pernicious going on.

## Change in underlying behavior:

* Android: it was broken ❌  now it works ✅ 
* Safari (iOS) / Chrome (iOS) / any iOS: no change (was previously using native HLS, and still is)
* Safari (Desktop): change: was previously using native HLS, now is using MSE
* Chrome (Desktop): no change (was previously using MSE, and now still is)
* Firefox (Desktop): no change (was previously using MSE, and now still is)

The only actual change is in Safari Desktop and I think we can live with that.