### PR TITLE
fix: only trigger fatal errors on player

### DIFF
--- a/src/tech/hlsjs.js
+++ b/src/tech/hlsjs.js
@@ -76,7 +76,12 @@ class HlsJs {
       // do this for hlsError events.
       if (eventName === Hls.Events.ERROR) {
         this.hls.on(eventName, (_event, hlsError) => {
-          const { type } = hlsError;
+          const { type, fatal } = hlsError;
+
+          if (!fatal) {
+            return;
+          }
+
           const code = ErrorTypeMap[type] ?? ErrorTypeMap.DEFAULT;
           this.tech.error({ code, hlsError });
         });


### PR DESCRIPTION
hls.js triggers a bunch of errors on various occasions. A lot of the errors are automatically recovered by hls.js, these are non-fatal errors. Video.js's error events are basically reserved for fatal errors, therefore, we should only bubble up fatal errors.