### PR TITLE
Update ci.yaml for brownout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run integration and e2e testing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This updates GH actions CI to latest given the Ubuntu 20.04 brownout