### PR TITLE
Upgrade video.js & hls.js; replace videojs-http-source-selector with videojs-hls-quality-selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
-        "hls.js": "^1.6.7",
-        "video.js": "^7.21.2",
-        "videojs-contrib-quality-levels": "^2.1.0",
-        "videojs-http-source-selector": "^1.1.6",
+        "hls.js": "^1.6.13",
+        "video.js": "^8.23.1",
+        "videojs-contrib-quality-levels": "^4.1.0",
+        "videojs-hls-quality-selector": "^2.0.0",
         "videojs-mux": "^4.21.10"
       },
       "devDependencies": {
@@ -482,9 +482,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2325,35 +2326,36 @@
       "dev": true
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.16.3.tgz",
-      "integrity": "sha512-91CJv5PnFBzNBvyEjt+9cPzTK/xoVixARj2g7ZAvItA+5bx8VKdk5RxCz/PP2kdzz9W+NiDUMPkdmTsosmy69Q==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.2.tgz",
+      "integrity": "sha512-VBQ3W4wnKnVKb/limLdtSD2rAd5cmHN70xoMf4OmuDd0t2kfJX04G+sfw6u2j8oOm2BXYM9E1f4acHruqKnM1g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "3.0.5",
-        "aes-decrypter": "3.1.3",
+        "@videojs/vhs-utils": "^4.1.1",
+        "aes-decrypter": "^4.0.2",
         "global": "^4.4.0",
-        "m3u8-parser": "4.8.0",
-        "mpd-parser": "^0.22.1",
-        "mux.js": "6.0.1",
-        "video.js": "^6 || ^7"
+        "m3u8-parser": "^7.2.0",
+        "mpd-parser": "^1.3.1",
+        "mux.js": "7.1.0",
+        "video.js": "^7 || ^8"
       },
       "engines": {
         "node": ">=8",
         "npm": ">=5"
       },
       "peerDependencies": {
-        "video.js": "^6 || ^7"
+        "video.js": "^8.19.0"
       }
     },
     "node_modules/@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
+        "global": "^4.4.0"
       },
       "engines": {
         "node": ">=8",
@@ -2361,9 +2363,10 @@
       }
     },
     "node_modules/@videojs/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.7.0.tgz",
+      "integrity": "sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "global": "~4.4.0",
@@ -2553,9 +2556,10 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -2640,12 +2644,13 @@
       }
     },
     "node_modules/aes-decrypter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.3.tgz",
-      "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.2.tgz",
+      "integrity": "sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0",
         "pkcs7": "^1.0.4"
       }
@@ -5904,9 +5909,10 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.7.tgz",
-      "integrity": "sha512-QW2fnwDGKGc9DwQUGLbmMOz8G48UZK7PVNJPcOUql1b8jubKx4/eMHNP5mGqr6tYlJNDG1g10Lx2U/qPzL6zwQ=="
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
+      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
+      "license": "Apache-2.0"
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -6318,11 +6324,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/individual": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g=="
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6560,7 +6561,8 @@
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "license": "MIT"
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -8460,11 +8462,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
-    },
     "node_modules/killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8592,12 +8589,13 @@
       }
     },
     "node_modules/m3u8-parser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.8.0.tgz",
-      "integrity": "sha512-UqA2a/Pw3liR6Df3gwxrqghCP17OpPlQj6RBPLYygf/ZSQ4MoSgvdvhvt35qV+3NaaA0FSZx93Ix+2brT1U7cA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz",
+      "integrity": "sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.1.1",
         "global": "^4.4.0"
       }
     },
@@ -8874,12 +8872,13 @@
       }
     },
     "node_modules/mpd-parser": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.22.1.tgz",
-      "integrity": "sha512-fwBebvpyPUU8bOzvhX0VQZgSohncbgYwUyJJoTSNpmy7ccD2ryiCvM7oRkn/xQH5cv73/xU7rJSNCLjdGFor0Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.1.tgz",
+      "integrity": "sha512-1FuyEWI5k2HcmhS1HkKnUAQV7yFPfXPht2DnRRGtoiiAAW+ESTbtEXIDpRkwdU+XyrQuwrIym7UkoPKsZ0SyFw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^3.0.5",
+        "@videojs/vhs-utils": "^4.0.0",
         "@xmldom/xmldom": "^0.8.3",
         "global": "^4.4.0"
       },
@@ -8918,9 +8917,10 @@
       "integrity": "sha512-uczzXVraqMRmyYmpGh2zthTmBKvvc5D5yaVKQRgGhFOnF7E4nkhqNkdkQc4C0WTPzdqdPl5OtCelNWMF4tg5RQ=="
     },
     "node_modules/mux.js": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
-      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.1.0.tgz",
+      "integrity": "sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "global": "^4.4.0"
@@ -9729,6 +9729,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
       "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.5.5"
       },
@@ -10428,14 +10429,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
-      "dependencies": {
-        "individual": "^2.0.0"
-      }
-    },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -10473,14 +10466,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/safe-json-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
-      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
-      "dependencies": {
-        "rust-result": "^1.0.0"
-      }
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -12353,11 +12338,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/url-toolkit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -12427,50 +12407,59 @@
       }
     },
     "node_modules/video.js": {
-      "version": "7.21.7",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.21.7.tgz",
-      "integrity": "sha512-T2s3WFAht7Zjr2OSJamND9x9Dn2O+Z5WuHGdh8jI5SYh5mkMdVTQ7vSRmA5PYpjXJ2ycch6jpMjkJEIEU2xxqw==",
+      "version": "8.23.4",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.4.tgz",
+      "integrity": "sha512-qI0VTlYmKzEqRsz1Nppdfcaww4RSxZAq77z2oNSl3cNg2h6do5C8Ffl0KqWQ1OpD8desWXsCrde7tKJ9gGTEyQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.16.3",
-        "@videojs/vhs-utils": "^3.0.4",
-        "@videojs/xhr": "2.6.0",
-        "aes-decrypter": "3.1.3",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.8.0",
-        "mpd-parser": "0.22.1",
-        "mux.js": "6.0.1",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.5"
+        "@videojs/http-streaming": "^3.17.2",
+        "@videojs/vhs-utils": "^4.1.1",
+        "@videojs/xhr": "2.7.0",
+        "aes-decrypter": "^4.0.2",
+        "global": "4.4.0",
+        "m3u8-parser": "^7.2.0",
+        "mpd-parser": "^1.3.1",
+        "mux.js": "^7.0.1",
+        "videojs-contrib-quality-levels": "4.1.0",
+        "videojs-font": "4.2.0",
+        "videojs-vtt.js": "0.15.5"
       }
     },
     "node_modules/videojs-contrib-quality-levels": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-2.2.1.tgz",
-      "integrity": "sha512-cnF6OGGgoC/2nUrbdz54nzPm3BpEZQzMTpyekiX6AXs8imATX2sHbrUz97xXVSHITldk/+d7ZAUrdQYJJTyuug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.1.0.tgz",
+      "integrity": "sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "global": "^4.3.2",
-        "video.js": "^6 || ^7 || ^8"
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
       },
       "peerDependencies": {
-        "video.js": "^6 || ^7 || ^8"
+        "video.js": "^8"
       }
     },
     "node_modules/videojs-font": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
-      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-4.2.0.tgz",
+      "integrity": "sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ==",
+      "license": "Apache-2.0"
     },
-    "node_modules/videojs-http-source-selector": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/videojs-http-source-selector/-/videojs-http-source-selector-1.1.6.tgz",
-      "integrity": "sha512-6b5MmKTT2cVnrjtdNj4z1VO91udbXkZkTYA6LlD8WN2aHlG2rqFTmtMab4NK4nlkkkbRnm3c2q2IddL3jffLmg==",
+    "node_modules/videojs-hls-quality-selector": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-hls-quality-selector/-/videojs-hls-quality-selector-2.0.0.tgz",
+      "integrity": "sha512-x0AQKGwryDdD94s1it+Jolb6j1mg4Q+c7g1PlCIG6dXBdipVPaZmg71fxaFZJgx1k326DFnRaWrLxQ72/TKd2A==",
+      "license": "MIT",
       "dependencies": {
-        "global": "^4.3.2",
-        "video.js": "^7.0.0",
-        "videojs-contrib-quality-levels": "^2.0.4"
+        "global": "^4.4.0",
+        "video.js": "^8"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
       }
     },
     "node_modules/videojs-mux": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "hls.js": "^1.6.7",
-    "video.js": "^7.21.2",
-    "videojs-contrib-quality-levels": "^2.1.0",
-    "videojs-http-source-selector": "^1.1.6",
+    "hls.js": "^1.6.13",
+    "video.js": "^8.23.1",
+    "videojs-contrib-quality-levels": "^4.1.0",
+    "videojs-hls-quality-selector": "^2.0.0",
     "videojs-mux": "^4.21.10"
   },
   "files": [

--- a/src/demo/basic.html
+++ b/src/demo/basic.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+  <meta charset="UTF-8">
+  <title>Video.js + Mux Kit Example</title>
+    <link rel="stylesheet" href="../../dist/index.css"/>
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
-
+  <script src="../../dist/index.js"></script>
   <section>
     <h2>Basic example</h2>
     <video id="mux-default" class="video-js vjs-16-9" controls preload="auto" width="100%"

--- a/src/demo/custom-domain.html
+++ b/src/demo/custom-domain.html
@@ -1,10 +1,18 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+  <meta charset="UTF-8">
+  <title>Mux Video.js Kit</title>
+    <link
+    rel="stylesheet"
+    href="../../dist/index.css"
+  />
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
+  <script src="../../dist/index.js"></script>
 
   <section>
     <h2>Custom domain</h2>

--- a/src/demo/data.html
+++ b/src/demo/data.html
@@ -1,11 +1,18 @@
 <!DOCTYPE html>
 <html>
 
-<head> </head>
+<head>
+  <meta charset="UTF-8">
+  <title>Mux Video.js Kit</title>
+    <link
+    rel="stylesheet"
+    href="../../dist/index.css"
+  />
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
-
+  <script src="../../dist/index.js"></script>
   <section>
     <h2>Data integration</h2>
     <video id="mux-default" class="video-js vjs-16-9" controls preload="auto" width="100%"
@@ -14,7 +21,7 @@
           "timelineHoverPreviews": true,
           "plugins": {
             "mux": {
-              "debug": false,
+              "debug": true,
               "data":{
                 "env_key": "ENV_KEY",
                 "video_title": "Mad Max"

--- a/src/demo/options.html
+++ b/src/demo/options.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+  <meta charset="UTF-8">
+  <title>Mux Video.js Kit</title>
+    <link rel="stylesheet" href="../../dist/index.css"/>
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
+  <script src="../../dist/index.js"></script>
 
   <section>
     <h2>Hls.js options example</h2>

--- a/src/demo/quality-levels.html
+++ b/src/demo/quality-levels.html
@@ -1,18 +1,21 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+  <link rel="stylesheet" href="../../dist/index.css">
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
-
+  <script src="../../dist/index.js"></script>
+  
   <section>
     <h2>Quality Levels example</h2>
     <video id="mux-default" class="video-js vjs-16-9" controls preload="auto" width="100%"
       poster="https://image.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/thumbnail.jpg"
       data-setup='{
         "plugins": {
-          "httpSourceSelector": {}
+          "hlsQualitySelector": {}
         }
       }'>
       <source src="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe" type="video/mux" />

--- a/src/demo/signed.html
+++ b/src/demo/signed.html
@@ -1,10 +1,18 @@
 <!DOCTYPE html>
 <html>
 
-<head> </head>
+<head>
+  <meta charset="UTF-8">
+  <title>Mux Video.js Kit</title>
+    <link
+    rel="stylesheet"
+    href="../../dist/index.css"
+  />
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
+  <script src="../../dist/index.js"></script>
 
   <section>
     <h2>Signed URLs</h2>

--- a/src/demo/subtitles.html
+++ b/src/demo/subtitles.html
@@ -1,11 +1,18 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+  <meta charset="UTF-8">
+  <title>Mux Video.js Kit</title>
+    <link
+    rel="stylesheet"
+    href="../../dist/index.css"
+  />
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
-
+  <script src="../../dist/index.js"></script>
   <section>
     <h2>Subtitles example</h2>
     <video id="mux-default" class="video-js vjs-16-9" controls preload="auto" width="100%"

--- a/src/demo/thumbnails.html
+++ b/src/demo/thumbnails.html
@@ -1,11 +1,17 @@
 <!DOCTYPE html>
 <html>
 
-<head></head>
+<head>
+    <title>Mux Video.js Kit</title>
+    <link
+    rel="stylesheet"
+    href="../../dist/index.css"
+  />
+</head>
 
 <body>
   <h1>Mux Video.js Kit</h1>
-
+  <script src="../../dist/index.js"></script>
   <section>
     <h2>Thumbnail preview scrubber</h2>
     <video id="mux-thumbnails" class="video-js vjs-16-9" controls preload="auto"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import videojs from 'video.js';
 import 'videojs-contrib-quality-levels';
-import 'videojs-http-source-selector';
+import 'videojs-hls-quality-selector';
 import './style/index.scss';
 
 import './tech/hlsjs';
@@ -48,6 +48,10 @@ videojs.use('video/mux', (player) => {
       if (player.mux && player.mux.addHLSJS) {
         setupMuxDataTracking(player);
       }
+
+      player.hlsQualitySelector({
+        displayCurrentQuality: true,
+      });
 
       if (typeof setupSubtitlesForPlayer !== 'undefined') {
         setupSubtitlesForPlayer(player);

--- a/src/plugins/vtt-thumbnails.js
+++ b/src/plugins/vtt-thumbnails.js
@@ -45,7 +45,7 @@ const onPlayerReady = (player, options) => {
  */
 const vttThumbnails = function(options) {
   this.ready(() => {
-    onPlayerReady(this, videojs.mergeOptions(defaults, options));
+    onPlayerReady(this, videojs.obj.merge(defaults, options));
   });
 };
 

--- a/src/style/components/_text-tracks.scss
+++ b/src/style/components/_text-tracks.scss
@@ -1,5 +1,5 @@
 /* Hide the captions settings item from the captions menu. */
 /* This is because hls.js tech can't control formatting. */
-.vjs-texttrack-settings {
+li.vjs-menu-item.vjs-texttrack-settings {
     display: none;
   }


### PR DESCRIPTION
resolve [109](https://github.com/muxinc/videojs-mux-kit/issues/109)

- Updated video.js and hls.js dependencies to latest versions
- Removed videojs-http-source-selector (outdated / unmaintained)
- Added videojs-hls-quality-selector, which is better maintained and works with video.js v8
- Update demos with missing imports